### PR TITLE
Support GPTQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,12 +24,33 @@ Official codebase for [**Shortened LLaMA: Depth Pruning for Large Language Model
 Note on package versions:
 </summary>
 
+
 - Part of the below repositories is included for evaluation:
   - `src/LLMPruner`: horseee/LLM-Pruner version [213ffa4](https://github.com/horseee/LLM-Pruner/tree/213ffa4d02f92f16d29219a97fd01a8622db1550)
   - `src/lm_eval`: EleutherAI/lm-evaluation-harness version [3326c54](https://github.com/EleutherAI/lm-evaluation-harness/tree/3326c547a733d598b4377e54be96e194861b964c)
 - Torch version used in our experiments: `2.0.1` for RTX3090 & A100; `2.1.1` for H100. 
 
 </details>
+
+<details>
+<summary>
+(optional) GPTQ Support:
+</summary>
+
+
+- Post-training quantization can be further applied to our pruned model. 
+- We applied GPTQ on the pruned & re-trained models.
+  - repo: [AutoGPTQ](https://github.com/AutoGPTQ/AutoGPTQ/tree/v0.7.1) version `0.7.1`
+- To install the required packages, we recommend installation from source as follows:
+  ```bash
+  git clone https://github.com/AutoGPTQ/AutoGPTQ.git
+  cd AutoGPTQ
+  git checkout v0.7.1
+  pip install -vvv -e .
+  ```
+
+</details>
+
 
 
 ## Models from Aggressive Pruning & CPT Retraining (arXiv-v2):
@@ -136,6 +157,11 @@ The scripts perform (1) block pruning ➔ (2) LoRA-based retraining ➔ (3) zero
 - To measure (1) PPL on WikiText2 & PTB, and (2) accuracy on seven commonsense reasoning tasks, use: (EleutherAI/lm-evaluation-harness version [3326c54](https://github.com/EleutherAI/lm-evaluation-harness/tree/3326c547a733d598b4377e54be96e194861b964c))
   ```bash
   bash script/evaluate.sh
+  ```
+
+- (Optional) Any post-training quantization method can be applied on our pruned models. Following example script quantize pruned vicuna-7b model with GPTQ and measuring ppl & accuracy (same as `script/evaluate.sh`):
+  ```bash
+  bash script/quantize_gptq_vicuna-7b.sh
   ```
 
 - To measure latency & throughput, use:

--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ The scripts perform (1) block pruning ➔ (2) LoRA-based retraining ➔ (3) zero
   bash script/evaluate.sh
   ```
 
-- (Optional) Any post-training quantization method can be applied on our pruned models. Following example script quantize pruned vicuna-7b model with GPTQ and measuring ppl & accuracy (same as `script/evaluate.sh`):
+- (Optional) Any post-training quantization method can be applied to our pruned models. The example script quantizes our pruned models using GPTQ and measures their performance with `script/evaluate.sh`:
   ```bash
   bash script/quantize_gptq_vicuna-7b.sh
   ```

--- a/script/measure_vram.sh
+++ b/script/measure_vram.sh
@@ -11,11 +11,10 @@ run_command() {
     done
 }
 
-#run_command "baffo32/decapoda-research-llama-7B-hf" "llama-1-7b" "--fix_decapoda_config"
-#run_command "nota-ai/st-llama-1-5.5b-ppl" "st-llama-1-5.5b-ppl" "--fix_decapoda_config"
+run_command "baffo32/decapoda-research-llama-7B-hf" "llama-1-7b" "--fix_decapoda_config"
+run_command "nota-ai/st-llama-1-5.5b-ppl" "st-llama-1-5.5b-ppl" "--fix_decapoda_config"
 
-#run_command "lmsys/vicuna-13b-v1.3" "vicuna-13b-v1.3" ""
-#run_command "nota-ai/st-vicuna-v1.3-10.5b-ppl" "st-vicuna-v1.3-10.5b-ppl" ""
+run_command "lmsys/vicuna-13b-v1.3" "vicuna-13b-v1.3" ""
+run_command "nota-ai/st-vicuna-v1.3-10.5b-ppl" "st-vicuna-v1.3-10.5b-ppl" ""
 
-TOKENIZER="nota-ai/only-prune_st-vicuna-v1.3-3.7b-ppl"
-run_command "quantized_models/GPTQ/st-vicuna-v1.3-3.7b-ppl-CPT-iter-2208000" "st-vicuna-v1.3-3.7b-ppl-CPT-iter-2208000-GPTQ" "--tokenizer $TOKENIZER"
+run_command "quantized_models/GPTQ/st-vcn-5.5b-CPT" "st-vcn-5.5b-CPT-GPTQ" ""

--- a/script/measure_vram.sh
+++ b/script/measure_vram.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 export CUDA_VISIBLE_DEVICES=0
 
-run_command () {    
+run_command() {
     for batch_size in {1,16,8,32,64,128,256}; do
         for max_seq_len in {128,512}; do
             python src/gen_batch_eval_vram.py --base_model $1 \
@@ -11,8 +11,11 @@ run_command () {
     done
 }
 
-run_command "baffo32/decapoda-research-llama-7B-hf" "llama-1-7b" "--fix_decapoda_config"
-run_command "nota-ai/st-llama-1-5.5b-ppl" "st-llama-1-5.5b-ppl" "--fix_decapoda_config"
+#run_command "baffo32/decapoda-research-llama-7B-hf" "llama-1-7b" "--fix_decapoda_config"
+#run_command "nota-ai/st-llama-1-5.5b-ppl" "st-llama-1-5.5b-ppl" "--fix_decapoda_config"
 
-run_command "lmsys/vicuna-13b-v1.3" "vicuna-13b-v1.3" ""
-run_command "nota-ai/st-vicuna-v1.3-10.5b-ppl" "st-vicuna-v1.3-10.5b-ppl" ""
+#run_command "lmsys/vicuna-13b-v1.3" "vicuna-13b-v1.3" ""
+#run_command "nota-ai/st-vicuna-v1.3-10.5b-ppl" "st-vicuna-v1.3-10.5b-ppl" ""
+
+TOKENIZER="nota-ai/only-prune_st-vicuna-v1.3-3.7b-ppl"
+run_command "quantized_models/GPTQ/st-vicuna-v1.3-3.7b-ppl-CPT-iter-2208000" "st-vicuna-v1.3-3.7b-ppl-CPT-iter-2208000-GPTQ" "--tokenizer $TOKENIZER"

--- a/script/quantize_gptq_vicuna-7b.sh
+++ b/script/quantize_gptq_vicuna-7b.sh
@@ -11,19 +11,20 @@ evaluate() {
 }
 
 BASE_MODEL_PATHS=(
-    "nota-ai/only-prune_st-vicuna-v1.3-2.7b-ppl" # st-vcn-2.7b-prunedinit
-    "/data/gmkim/checkpoints/only-prune_st-vicuna-v1.3-3.7b-ppl/hf/iter-2208000"
+    "nota-ai/cpt_st-vicuna-v1.3-3.7b-ppl"
+    "nota-ai/only-prune_st-vicuna-v1.3-2.7b-ppl"
 
 )
 
 QUANTIZED_MODEL_DIRS=(
-    "quantized_models/GPTQ/st-vcn-2.7b-prunedinit" # st-vcn-2.7b-prunedinit
-    "quantized_models/GPTQ/st-vicuna-v1.3-3.7b-ppl-CPT-iter-2208000"
+    "quantized_models/GPTQ/st-vcn-3.7b-CPT"
+    "quantized_models/GPTQ/st-vcn-2.7b-prunedinit"
+
 )
 
 EVAL_NAMES=(
-    "st-vcn-2.7b-prunedinit-GPTQ"
     "st-vcn-3.7b-CPT-GPTQ"
+    "st-vcn-2.7b-prunedinit-GPTQ"
 )
 
 NUM_EVAL=${#BASE_MODEL_PATHS[@]}

--- a/script/quantize_gptq_vicuna-7b.sh
+++ b/script/quantize_gptq_vicuna-7b.sh
@@ -11,20 +11,25 @@ evaluate() {
 }
 
 BASE_MODEL_PATHS=(
+    "nota-ai/cpt_st-vicuna-v1.3-5.5b-ppl"
     "nota-ai/cpt_st-vicuna-v1.3-3.7b-ppl"
-    "nota-ai/only-prune_st-vicuna-v1.3-2.7b-ppl"
+    "nota-ai/cpt_st-vicuna-v1.3-2.7b-ppl"
+    "nota-ai/cpt_st-vicuna-v1.3-1.5b-ppl"
 
 )
 
 QUANTIZED_MODEL_DIRS=(
+    "quantized_models/GPTQ/st-vcn-5.5b-CPT"
     "quantized_models/GPTQ/st-vcn-3.7b-CPT"
-    "quantized_models/GPTQ/st-vcn-2.7b-prunedinit"
-
+    "quantized_models/GPTQ/st-vcn-2.7b-CPT"
+    "quantized_models/GPTQ/st-vcn-1.5b-CPT"
 )
 
 EVAL_NAMES=(
+    "st-vcn-5.5b-CPT-GPTQ"
     "st-vcn-3.7b-CPT-GPTQ"
-    "st-vcn-2.7b-prunedinit-GPTQ"
+    "st-vcn-2.7b-CPT-GPTQ"
+    "st-vcn-1.5b-CPT-GPTQ"
 )
 
 NUM_EVAL=${#BASE_MODEL_PATHS[@]}

--- a/script/quantize_gptq_vicuna-7b.sh
+++ b/script/quantize_gptq_vicuna-7b.sh
@@ -51,6 +51,5 @@ for ((i = 0; i < $NUM_EVAL; i++)); do
     python src/quantize_gptq.py --base_model $BASE_MODEL_PATH --quantized_model_dir $QUANTIZED_MODEL_DIR
 
     # Evaluate
-    evaluate $QUANTIZED_MODEL_DIR $EVAL_NAME "--tokenizer $BASE_MODEL_PATH" &
-
+    evaluate $QUANTIZED_MODEL_DIR $EVAL_NAME ""
 done

--- a/script/quantize_vicuna-7b.sh
+++ b/script/quantize_vicuna-7b.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+evaluate() {
+    python src/eval_ppl.py --base_model $1 --output_dir results/$2/ppl --device cuda $3
+
+    python src/eval_zeroshot_acc.py \
+        --model hf-causal-experimental --no_cache \
+        --model_args pretrained=$1 \
+        --tasks openbookqa,arc_easy,winogrande,hellaswag,arc_challenge,piqa,boolq \
+        --device cuda --output_json results/$2/zeroshot_acc.json | tee results/$2/zeroshot_acc.txt
+}
+
+BASE_MODEL_PATHS=(
+    "nota-ai/only-prune_st-vicuna-v1.3-2.7b-ppl" # st-vcn-2.7b-prunedinit
+    "/data/gmkim/checkpoints/only-prune_st-vicuna-v1.3-3.7b-ppl/hf/iter-2208000"
+
+)
+
+QUANTIZED_MODEL_DIRS=(
+    "quantized_models/GPTQ/st-vcn-2.7b-prunedinit" # st-vcn-2.7b-prunedinit
+    "quantized_models/GPTQ/st-vicuna-v1.3-3.7b-ppl-CPT-iter-2208000"
+)
+
+EVAL_NAMES=(
+    "st-vcn-2.7b-prunedinit-GPTQ"
+    "st-vcn-3.7b-CPT-GPTQ"
+)
+
+NUM_EVAL=${#BASE_MODEL_PATHS[@]}
+
+for ((i = 0; i < $NUM_EVAL; i++)); do
+    BASE_MODEL_PATH=${BASE_MODEL_PATHS[$i]}
+    QUANTIZED_MODEL_DIR=${QUANTIZED_MODEL_DIRS[$i]}
+    EVAL_NAME=${EVAL_NAMES[$i]}
+
+    echo "BASE_MODEL_PATH: $BASE_MODEL_PATH"
+    echo "QUANTIZED_MODEL_DIR: $QUANTIZED_MODEL_DIR"
+    echo "EVAL_NAME: $EVAL_NAME"
+
+    if [ ! -d "$QUANTIZED_MODEL_DIR" ]; then
+        mkdir -p "$QUANTIZED_MODEL_DIR"
+    fi
+
+    # Run quantization
+    python src/quantize_gptq.py --base_model $BASE_MODEL_PATH --quantized_model_dir $QUANTIZED_MODEL_DIR
+
+    # Evaluate
+    evaluate $QUANTIZED_MODEL_DIR $EVAL_NAME "--tokenizer $BASE_MODEL_PATH" &
+
+done

--- a/src/dataset.py
+++ b/src/dataset.py
@@ -86,11 +86,11 @@ def get_examples(
     seq_len=128,
     field_name="text",
     add_bos_to_every=False,
+    return_raw_dataset=False,
 ):
     if dataset == "c4":
         traindata = load_dataset(
             "allenai/c4",
-            "allenai--c4",
             data_files={"train": "en/c4-train.00000-of-01024.json.gz"},
             split="train",
         )
@@ -98,6 +98,9 @@ def get_examples(
         traindata = load_dataset("bookcorpus", split="train")
     else:
         raise NotImplementedError
+
+    if return_raw_dataset:
+        return traindata
 
     tokenized_samples, history = [], []
 

--- a/src/lm_eval/models/huggingface.py
+++ b/src/lm_eval/models/huggingface.py
@@ -290,7 +290,7 @@ class HuggingFaceAutoLM(BaseLM):
         bnb_4bit_use_double_quant: Optional[bool] = False,
     ) -> transformers.AutoModel:
         """Returns a pre-trained pytorch model from a pre-trained model configuration."""
-        if not quantized:
+        if 'GPTQ' not in pretrained and not quantized:
             if load_in_4bit:
                 assert transformers.__version__ >= "4.30.0", "load_in_4bit requires transformers >= 4.30.0"
             model_kwargs = {}
@@ -319,15 +319,13 @@ class HuggingFaceAutoLM(BaseLM):
             from auto_gptq import AutoGPTQForCausalLM
             model = AutoGPTQForCausalLM.from_quantized(
                 pretrained,
-                model_basename=None if quantized == True else Path(quantized).stem,
-                device_map=device_map,
+                device="cuda:0",
                 max_memory=max_memory,
-                trust_remote_code=trust_remote_code,
-                use_safetensors=True if quantized == True else quantized.endswith('.safetensors'),
-                use_triton=gptq_use_triton,
-                warmup_triton=gptq_use_triton,
-                inject_fused_attention=inject_fused_attention,
+                trust_remote_code=True,
+                use_safetensors=True,
+                use_triton=False,
             )
+            
         return model
 
     def _create_auto_model_peft(

--- a/src/quantize_gptq.py
+++ b/src/quantize_gptq.py
@@ -1,0 +1,125 @@
+import argparse
+import logging
+import random
+
+from transformers import AutoTokenizer
+import torch
+import numpy as np
+from datasets import load_dataset
+
+from auto_gptq import AutoGPTQForCausalLM, BaseQuantizeConfig
+
+logging.basicConfig(
+    format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
+    level=logging.INFO,
+    datefmt="%Y-%m-%d %H:%M:%S",
+)
+
+
+def get_dataset(
+    nsamples, seed, seqlen, tokenizer, load_dataset_kwargs, buffer_size=5000
+):
+
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+    np.random.seed(seed)
+    random.seed(seed)
+
+    # load raw dataset from Huggingface datasets
+    raw_data = load_dataset(**load_dataset_kwargs)
+
+    all_text = "\n\n".join(
+        raw_data["text"][:buffer_size]
+    )  # further reduce sample size (large enough to cover nsamples*seqlen tokens)
+
+    encoding = tokenizer(all_text, return_tensors="pt")
+
+    # gather dataset
+    dataset = []
+    for _ in range(nsamples):
+        i = random.randint(0, encoding.input_ids.shape[1] - seqlen - 1)
+        j = i + seqlen
+        inp = encoding.input_ids[:, i:j]
+        attention_mask = torch.ones_like(inp)
+        dataset.append({"input_ids": inp, "attention_mask": attention_mask})
+
+    return dataset
+
+
+def quantize(base_model, tokenizer_name=None, quantized_model_dir=None):
+    if tokenizer_name is None:
+        tokenizer_name = base_model
+
+    if quantized_model_dir is None:
+        quantized_model_dir = f"{base_model.split('/')[-1]}-GPTQ"
+
+    logging.info(f"base_model = {base_model}, tokenizer = {tokenizer_name}")
+
+    # base quantization config example # TODO. choose optimal one
+    quantize_config = BaseQuantizeConfig(
+        bits=4,  # quantize model to 4-bit
+        group_size=128,  # it is recommended to set the value to 128
+        desc_act=True,  # set to False can significantly speed up inference but the perplexity may slightly bad
+    )  # ppl is important than latency for now
+
+    # load un-quantized model, by default, the model will always be loaded into CPU memory
+    model = AutoGPTQForCausalLM.from_pretrained(base_model, quantize_config)
+
+    # get calibration data
+    # NOTE: please provide proper option for loading only subset of large datasets
+    load_dataset_kwargs = {
+        "path": "allenai/c4",
+        "split": "train",
+        "data_files": {"train": "en/c4-train.00000-of-01024.json.gz"},
+    }
+
+    try:
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, use_fast=False)
+    except Exception:
+        tokenizer = AutoTokenizer.from_pretrained(tokenizer_name, use_fast=True)
+
+    examples = get_dataset(
+        nsamples=128,
+        seed=0,
+        seqlen=2048,
+        tokenizer=tokenizer,
+        load_dataset_kwargs=load_dataset_kwargs,
+    )
+
+    # quantize model, the examples should be list of dict whose keys can only be "input_ids" and "attention_mask"
+    print(
+        'quantize model, the examples should be list of dict whose keys can only be "input_ids" and "attention_mask"'
+    )
+    model.quantize(examples, use_triton=False)
+
+    # save quantized model using safetensors
+    model.save_quantized(quantized_model_dir, use_safetensors=True)
+    tokenizer.save_pretrained(quantized_model_dir)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--base_model",
+        type=str,
+        default="",
+        help="base model name",
+    )
+    parser.add_argument(
+        "--tokenizer", type=str, default=None, help="if None, base model name is used"
+    )
+    parser.add_argument(
+        "--quantized_model_dir",
+        type=str,
+        default=None,
+        help="if None, it is inferred from base_model",
+    )
+
+    args = parser.parse_args()
+
+    model = quantize(
+        base_model=args.base_model,
+        tokenizer_name=args.tokenizer,
+        quantized_model_dir=args.quantized_model_dir,
+    )

--- a/src/utils.py
+++ b/src/utils.py
@@ -67,7 +67,19 @@ def get_model(
     tokenizer = base_model if tokenizer is None else tokenizer
     if model_type == "pretrain":
         config = AutoConfig.from_pretrained(base_model)
-        if (
+        if "gptq" in base_model.lower():
+            from auto_gptq import AutoGPTQForCausalLM
+
+            model = AutoGPTQForCausalLM.from_quantized(
+                base_model,
+                use_safetensors=True,
+                trust_remote_code=True,
+                use_triton=False,
+                quantize_config=None,
+                # device=device,  # necessary to load AutoGPTQ model on cuda `device` without loading to cpu first
+            )
+            tokenizer = AutoTokenizer.from_pretrained(tokenizer)
+        elif (
             "LlamaForCausalLM" in config.__getattribute__("architectures")
             and "llama-3" not in base_model.lower()
         ):

--- a/src/utils.py
+++ b/src/utils.py
@@ -76,7 +76,6 @@ def get_model(
                 trust_remote_code=True,
                 use_triton=False,
                 quantize_config=None,
-                # device=device,  # necessary to load AutoGPTQ model on cuda `device` without loading to cpu first
             )
             tokenizer = AutoTokenizer.from_pretrained(tokenizer)
         elif (


### PR DESCRIPTION
## Description
* Add [installation](https://github.com/Nota-NetsPresso/shortened-llm/tree/main?tab=readme-ov-file#installation), and [example script](https://github.com/Nota-NetsPresso/shortened-llm/blob/main/script/quantize_gptq_vicuna-7b.sh) for using [GPTQ](https://github.com/AutoGPTQ/AutoGPTQ)
</br>

## Changes
* Post-training quantization with GPTQ can be applied to pruned models.
* Measuring ppl (Wikitext-2, PTB), zero-shot acc (CommonSence), and VRAM usage is available for GPTQ-quantized models.